### PR TITLE
Default Token Address Linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@ Some generic schemas for improving the usability of Frequency
 
 ## Schemas
 
+### Default Token Address
+
+- Goal: Allow MSAs to list their default token sending and receiving addresses, both from Frequency and other chains
+- Payload Location Options
+    - Itemized: Each piece of data is atomic
+    - Signature Required: Creating or removing connecting addresses should require user sign-off
+
+#### Data
+
+- Address: String form of the token address for the specific chain
+- Token: SLIP-0044 Chain Identifier
+
+#### References
+
+- [SLIP-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
 
 ## Use to Deploy Schemas
 

--- a/schemas/defaultTokenAddress.js
+++ b/schemas/defaultTokenAddress.js
@@ -1,0 +1,22 @@
+/**
+ * Token Address is a way to record a token sending and receiving addresses for an MSA
+ * Should be stored using Itemized and Signature Required
+ * SLIP-0044 Standard: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+ */
+export default {
+  type: "record",
+  name: "DefaultTokenAddress",
+  namespace: "frequency",
+  fields: [
+    {
+      name: "token_slip_0044",
+      type: "int",
+      doc: "Network for this token address using SLIP-0044 registered coin type integers",
+    },
+    {
+      name: "address",
+      type: "string",
+      doc: "The address as a string encoded in standard way for the given coin type",
+    },
+  ],
+};

--- a/schemas/defaultTokenAddress.spec.js
+++ b/schemas/defaultTokenAddress.spec.js
@@ -1,0 +1,25 @@
+import { expect, test, it } from "vitest";
+import avro from "avsc";
+import defaultTokenAddress from "./defaultTokenAddress.js";
+
+test("Token Addresses Schema is Avro", () => {
+  const schema = avro.Type.forSchema(defaultTokenAddress);
+  expect(schema).toBeDefined();
+});
+
+test("Token Addresses Schema can take the correct data", () => {
+  const schema = avro.Type.forSchema(defaultTokenAddress);
+  const dot = schema.toBuffer({
+    token_slip_0044: 354,
+    address: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+  });
+  expect(dot).toBeDefined();
+  expect(schema.fromBuffer(dot).token_slip_0044).toBe(354);
+
+  const btc = schema.toBuffer({
+    token_slip_0044: 0,
+    address: "34xp4vRoCGJym3xR7yCVPFHoCNxv4Twseo",
+  });
+  expect(btc).toBeDefined();
+  expect(schema.fromBuffer(btc).token_slip_0044).toBe(0);
+});

--- a/schemas/index.js
+++ b/schemas/index.js
@@ -1,1 +1,13 @@
-export const schemas = new Map([]);
+import * as defaultTokenAddress from "./defaultTokenAddress.js";
+
+export const schemas = new Map([
+  [
+    "defaultTokenAddress",
+    {
+      model: defaultTokenAddress,
+      modelType: "AvroBinary",
+      payloadLocation: "Itemized",
+      settings: ["SignatureRequired"],
+    },
+  ],
+]);

--- a/schemas/index.js
+++ b/schemas/index.js
@@ -2,7 +2,7 @@ import * as defaultTokenAddress from "./defaultTokenAddress.js";
 
 export const schemas = new Map([
   [
-    "defaultTokenAddress",
+    "default-token-address",
     {
       model: defaultTokenAddress,
       modelType: "AvroBinary",


### PR DESCRIPTION
## Goal

The goal of this PR is:
- Introduce a new schema for MSAs to be able to attach wallet addresses for payment to an MSA
- Setup the future structure for Frequency schemas based on https://github.com/LibertyDSNP/schemas

Closes #3

## Discussion

- *Question*: Itemized or Paginated? `Winner: Itemized`
    - Itemized: Requires a bit more work to keep up to date
    - Paginated: Easy editing of multiple and removal of out of date items
- *Question*: Indexed by `coin_type` or Array of Objects (Itemized Required)? `Winner: Array of Objects`
    - Indexed: Requires an array structure after it still to support multiple addresses with the same coin_type
    - Array: Has to be scanned fully each time, but likely a small dataset for most users

## Checklist

- [x] PR Self-Review and Commenting
- [x] Docs updated
- [x] Tests added

## How To Test the Changes

1. Clone the pr branch
2. `npm run test`
3. Start Frequency Chain
4. `npm run deploy`
